### PR TITLE
General bug fixes

### DIFF
--- a/ball.js
+++ b/ball.js
@@ -75,6 +75,11 @@ export const makeBall = (
   }
 
   const pop = (popperVelocity = false) => {
+    // Two overlapping blasts, or a blast and a tap in the same frame, can both
+    // reach the same bubble. Popping twice restarted the animation and fired
+    // onPop a second time.
+    if (popped) return;
+
     const transferringVelocity = popperVelocity
       ? popperVelocity
       : baseParticle.getVelocity();

--- a/ball.js
+++ b/ball.js
@@ -75,9 +75,6 @@ export const makeBall = (
   }
 
   const pop = (popperVelocity = false) => {
-    // Two overlapping blasts, or a blast and a tap in the same frame, can both
-    // reach the same bubble. Popping twice restarted the animation and fired
-    // onPop a second time.
     if (popped) return;
 
     const transferringVelocity = popperVelocity

--- a/builder/index.js
+++ b/builder/index.js
@@ -41,9 +41,12 @@ const populateListOfLevels = () => {
 
 const updateName = (newName) => (currentlyDisplayedData.name = newName);
 
-const updatePar = (newPar) => (currentlyDisplayedData.par = newPar);
+// Input values are strings. Exported as strings, par ends up concatenated
+// rather than summed when the game totals it across levels.
+const updatePar = (newPar) => (currentlyDisplayedData.par = parseInt(newPar));
 
-const updateGravity = (newGrav) => (currentlyDisplayedData.gravity = newGrav);
+const updateGravity = (newGrav) =>
+  (currentlyDisplayedData.gravity = parseFloat(newGrav));
 
 const updateLevelHref = () => {
   openPreviewEl.setAttribute(
@@ -132,7 +135,6 @@ layoutParEl.addEventListener("input", (e) => {
   e.preventDefault();
 });
 
-// This is triggering an error at L206 for some reason
 layoutGravityEl.addEventListener("change", (e) => {
   updateGravity(e.target.value);
   updateLevelHref();
@@ -168,10 +170,11 @@ document.addEventListener("keydown", (e) => {
       fillCell(selectedBallRow, selectedBallCell, makeLevelEmptyCell());
       clearSelection();
     }
-    if (key === "ArrowUp") ball.velocity.y--;
-    if (key === "ArrowRight") ball.velocity.x++;
-    if (key === "ArrowDown") ball.velocity.y++;
-    if (key === "ArrowLeft") ball.velocity.x--;
+    // makeLevelBall stores velocity under `v`
+    if (key === "ArrowUp") ball.v.y--;
+    if (key === "ArrowRight") ball.v.x++;
+    if (key === "ArrowDown") ball.v.y++;
+    if (key === "ArrowLeft") ball.v.x--;
     if (key === "Tab") {
       if (shiftKey) {
         const prevBallCellIndex = currentlyDisplayedData.balls[

--- a/builder/index.js
+++ b/builder/index.js
@@ -41,8 +41,6 @@ const populateListOfLevels = () => {
 
 const updateName = (newName) => (currentlyDisplayedData.name = newName);
 
-// Input values are strings. Exported as strings, par ends up concatenated
-// rather than summed when the game totals it across levels.
 const updatePar = (newPar) => (currentlyDisplayedData.par = parseInt(newPar));
 
 const updateGravity = (newGrav) =>
@@ -170,7 +168,6 @@ document.addEventListener("keydown", (e) => {
       fillCell(selectedBallRow, selectedBallCell, makeLevelEmptyCell());
       clearSelection();
     }
-    // makeLevelBall stores velocity under `v`
     if (key === "ArrowUp") ball.v.y--;
     if (key === "ArrowRight") ball.v.x++;
     if (key === "ArrowDown") ball.v.y++;

--- a/canvas.js
+++ b/canvas.js
@@ -10,13 +10,21 @@ export const makeCanvasManager = ({
   const context = element.getContext("2d", {
     colorSpace: "display-p3",
   });
-  const scale = window.devicePixelRatio;
+  const resizeSubscribers = [];
+  // Re-read on every resize rather than captured once: browser zoom and moving
+  // a window between monitors change it, and a stale value leaves the backing
+  // store at the wrong resolution
+  let scale = window.devicePixelRatio;
 
   const setCanvasSize = () => {
+    scale = window.devicePixelRatio;
     element.style.width = width + "px";
     element.style.height = height + "px";
     element.width = Math.floor(width * scale);
     element.height = Math.floor(height * scale);
+    // Assigning width or height resets the transform, but say so explicitly
+    // rather than depending on it
+    context.setTransform(1, 0, 0, 1, 0, 0);
     context.scale(scale, scale);
   };
 
@@ -28,6 +36,7 @@ export const makeCanvasManager = ({
     width = Math.min(window.innerWidth, maxWidth);
     height = window.innerHeight;
     setCanvasSize();
+    resizeSubscribers.forEach((subscriber) => subscriber());
   });
 
   return {
@@ -36,6 +45,8 @@ export const makeCanvasManager = ({
     getWidth: () => width,
     getHeight: () => height,
     getScaleFactor: () => scale,
+    // For anything that caches a measurement taken from the canvas size
+    onResize: (subscriber) => resizeSubscribers.push(subscriber),
   };
 };
 
@@ -63,6 +74,7 @@ export const makeOffscreenCanvas = ({
 
     offscreenElement.width = Math.floor(_width * _scale);
     offscreenElement.height = Math.floor(_height * _scale);
+    context.setTransform(1, 0, 0, 1, 0, 0);
     context.scale(_scale, _scale);
   };
 

--- a/canvas.js
+++ b/canvas.js
@@ -11,9 +11,6 @@ export const makeCanvasManager = ({
     colorSpace: "display-p3",
   });
   const resizeSubscribers = [];
-  // Re-read on every resize rather than captured once: browser zoom and moving
-  // a window between monitors change it, and a stale value leaves the backing
-  // store at the wrong resolution
   let scale = window.devicePixelRatio;
 
   const setCanvasSize = () => {
@@ -22,8 +19,6 @@ export const makeCanvasManager = ({
     element.style.height = height + "px";
     element.width = Math.floor(width * scale);
     element.height = Math.floor(height * scale);
-    // Assigning width or height resets the transform, but say so explicitly
-    // rather than depending on it
     context.setTransform(1, 0, 0, 1, 0, 0);
     context.scale(scale, scale);
   };
@@ -45,7 +40,6 @@ export const makeCanvasManager = ({
     getWidth: () => width,
     getHeight: () => height,
     getScaleFactor: () => scale,
-    // For anything that caches a measurement taken from the canvas size
     onResize: (subscriber) => resizeSubscribers.push(subscriber),
   };
 };

--- a/colors.js
+++ b/colors.js
@@ -112,7 +112,5 @@ export const randomColor = () => {
 export const getGradientBitmap = (sourceColor) => {
   const gradient = gradientBitmaps.find((g) => g.sourceColor === sourceColor);
 
-  // Level data can arrive from a URL, so the color isn't guaranteed to be one
-  // we've pre-rendered a bubble for
   return gradient ? gradient.bitmap : whiteGradientBitmap;
 };

--- a/colors.js
+++ b/colors.js
@@ -76,7 +76,7 @@ const makeBitmap = (gradientFunc) => {
     -bubbleRadius2x
   );
   strokeGradient.addColorStop(0, "rgba(255, 255, 255, .4)");
-  strokeGradient.addColorStop(1, "rgba(255, 255, 255, 0");
+  strokeGradient.addColorStop(1, "rgba(255, 255, 255, 0)");
 
   preRenderContext.strokeStyle = strokeGradient;
   preRenderContext.lineWidth = 2;
@@ -109,5 +109,10 @@ export const randomColor = () => {
   return colors[Math.floor(Math.random() * colors.length)];
 };
 
-export const getGradientBitmap = (sourceColor) =>
-  gradientBitmaps.find((g) => g.sourceColor === sourceColor).bitmap;
+export const getGradientBitmap = (sourceColor) => {
+  const gradient = gradientBitmaps.find((g) => g.sourceColor === sourceColor);
+
+  // Level data can arrive from a URL, so the color isn't guaranteed to be one
+  // we've pre-rendered a bubble for
+  return gradient ? gradient.bitmap : whiteGradientBitmap;
+};

--- a/grid.js
+++ b/grid.js
@@ -24,12 +24,15 @@ export const makeGrid = (
 
   const drawItems = (drawFunc) => {
     let truncatedIndex = false;
+    // Only give up the last cell to the "+N" badge when there are more items
+    // than fit. A grid that filled exactly was hiding a real item to show "+1".
+    const isTruncated = items.length > itemsPerRow * maxRows;
 
     items.forEach((item, index) => {
       const colIndex = index % itemsPerRow;
       const rowIndex = Math.floor(index / itemsPerRow);
       const lastRowItem =
-        rowIndex + 1 === maxRows && colIndex + 1 === itemsPerRow;
+        isTruncated && rowIndex + 1 === maxRows && colIndex + 1 === itemsPerRow;
 
       if (rowIndex < maxRows && !lastRowItem) {
         CTX.save();
@@ -41,12 +44,13 @@ export const makeGrid = (
 
         drawFunc(item, index);
         CTX.restore();
-      } else if (!truncatedIndex) {
+      } else if (truncatedIndex === false) {
+        // Not `!truncatedIndex` — index 0 is a valid place to start truncating
         truncatedIndex = index;
       }
     });
 
-    if (truncatedIndex) {
+    if (truncatedIndex !== false) {
       CTX.save();
       CTX.translate(
         edgeMargin +

--- a/grid.js
+++ b/grid.js
@@ -24,8 +24,6 @@ export const makeGrid = (
 
   const drawItems = (drawFunc) => {
     let truncatedIndex = false;
-    // Only give up the last cell to the "+N" badge when there are more items
-    // than fit. A grid that filled exactly was hiding a real item to show "+1".
     const isTruncated = items.length > itemsPerRow * maxRows;
 
     items.forEach((item, index) => {
@@ -45,7 +43,6 @@ export const makeGrid = (
         drawFunc(item, index);
         CTX.restore();
       } else if (truncatedIndex === false) {
-        // Not `!truncatedIndex` — index 0 is a valid place to start truncating
         truncatedIndex = index;
       }
     });

--- a/holdBlast.js
+++ b/holdBlast.js
@@ -71,7 +71,7 @@ export const makeHoldBlast = (
   );
   let gone = false;
   let numCollisions = 0;
-  let comboTrackerTimestamp = scoreStore.recordBlast(
+  let comboTrackerId = scoreStore.recordBlast(
     { x, y },
     startSize,
     numCollisions
@@ -79,7 +79,7 @@ export const makeHoldBlast = (
 
   const logCollision = () => {
     numCollisions++;
-    scoreStore.updateBlast(comboTrackerTimestamp, numCollisions);
+    scoreStore.updateBlast(comboTrackerId, numCollisions);
   };
 
   const getBlastProgress = () =>

--- a/index.js
+++ b/index.js
@@ -94,8 +94,10 @@ let previousLevelBalls;
 let balls;
 let ripples;
 let fireworks;
+let showInterstitialTimeout;
 
 function resetGame() {
+  clearTimeout(showInterstitialTimeout);
   activePointers = [];
   pointerTriggerOutput = [];
   previousLevelBalls = [];
@@ -129,20 +131,33 @@ function resetOngoingVisuals() {
   ripples = [];
 }
 
+// The last level and the missed-first-bubble screen both offer a restart
+// rather than a next level, so every way of dismissing an interstitial has to
+// route through here. Advancing off the last level walks past the end of the
+// level data.
+function advanceFromInterstitial() {
+  levelManager.isGameOver() ||
+  levelManager.isLastLevel() ||
+  levelManager.missedFirstBubble()
+    ? resetGame()
+    : levelManager.dismissInterstitialAndAdvanceLevel();
+}
+
 canvasManager.getElement().addEventListener("pointerdown", (e) => {
   const { pointerId, offsetX: x, offsetY: y } = e;
 
   if (levelManager.isInterstitialShowing()) {
     interstitialButtonManager.handleClick(
       { x, y },
-      levelManager.isGameOver() ||
-        levelManager.isLastLevel() ||
-        levelManager.missedFirstBubble()
-        ? resetGame
-        : levelManager.dismissInterstitialAndAdvanceLevel,
+      advanceFromInterstitial,
       shareImageManager.share
     );
   } else {
+    // Capture the pointer so a drag that ends outside the canvas still
+    // delivers pointerup here. Without it the pointer is never removed and its
+    // slingshot preview stays on screen.
+    canvasManager.getElement().setPointerCapture(pointerId);
+
     activePointers.push(
       makeActivePointer(
         canvasManager,
@@ -166,16 +181,29 @@ canvasManager.getElement().addEventListener("pointerdown", (e) => {
 
 canvasManager.getElement().addEventListener("pointerup", (e) => {
   const { pointerId, offsetX: x, offsetY: y } = e;
+  const releasedPointers = activePointers.filter(
+    (pointer) => pointerId === pointer.getId()
+  );
 
-  activePointers.forEach((pointer, pointerIndex) => {
-    if (pointerId === pointer.getId()) {
-      pointer.setPosition({ x, y });
-      activePointers.splice(pointerIndex, 1);
-      if (!levelManager.isInterstitialShowing()) pointer.trigger();
-    }
+  activePointers = activePointers.filter(
+    (pointer) => pointerId !== pointer.getId()
+  );
+
+  releasedPointers.forEach((pointer) => {
+    pointer.setPosition({ x, y });
+    if (!levelManager.isInterstitialShowing()) pointer.trigger();
   });
 
   e.preventDefault();
+});
+
+// The browser can take a pointer away mid-gesture, e.g. a system swipe or a
+// touch it decides belongs to something else. Drop it rather than leaving it
+// active and drawing forever.
+canvasManager.getElement().addEventListener("pointercancel", (e) => {
+  activePointers = activePointers.filter(
+    (pointer) => e.pointerId !== pointer.getId()
+  );
 });
 
 canvasManager.getElement().addEventListener("pointermove", (e) => {
@@ -194,10 +222,15 @@ canvasManager.getElement().addEventListener("pointermove", (e) => {
 document.addEventListener("keydown", ({ key }) => {
   const validKey = key === " " || key === "Enter";
 
-  if (validKey && levelManager.isGameOver()) {
-    resetGame();
-  } else if (validKey && levelManager.isInterstitialShowing()) {
-    levelManager.dismissInterstitialAndAdvanceLevel();
+  // Gated on the button's own delay so the keyboard can't skip an interstitial
+  // before its button is live
+  if (
+    validKey &&
+    levelManager.isInterstitialShowing() &&
+    interstitialButtonManager.hasDelayPassed()
+  ) {
+    document.body.classList.remove("buttonHover");
+    advanceFromInterstitial();
   }
 });
 
@@ -237,12 +270,14 @@ const cameraWrapper = (drawFunc) => {
 };
 
 const triggerTimedOutHoldBlasts = () => {
-  activePointers.forEach((p, pointerIndex) => {
-    if (p.isHoldBlast() && p.getDuration() >= BLAST_MAX_DURATION) {
-      activePointers.splice(pointerIndex, 1);
-      p.trigger();
-    }
-  });
+  const timedOut = activePointers.filter(
+    (p) => p.isHoldBlast() && p.getDuration() >= BLAST_MAX_DURATION
+  );
+
+  if (timedOut.length) {
+    activePointers = activePointers.filter((p) => !timedOut.includes(p));
+    timedOut.forEach((p) => p.trigger());
+  }
 };
 
 const detectCollisionsForGameObjects = () => {
@@ -469,9 +504,15 @@ function onPointerTrigger(output) {
 }
 
 function onPop() {
-  if (balls.filter((b) => b.inPlay()) <= 0) {
-    // Pause before showing interstitial so user can see the final bubble pop
-    setTimeout(levelManager.showLevelInterstitial, 600);
+  if (balls.filter((b) => b.inPlay()).length === 0) {
+    // Pause before showing interstitial so user can see the final bubble pop.
+    // Tracked so that losing the last life inside this window doesn't let a
+    // stale timer restart the game over screen behind the player.
+    clearTimeout(showInterstitialTimeout);
+    showInterstitialTimeout = setTimeout(
+      levelManager.showLevelInterstitial,
+      600
+    );
   }
 }
 
@@ -483,7 +524,7 @@ function onMiss() {
 
     if (lifeManager.getLives() <= 0) {
       onGameEnd();
-    } else if (balls.filter((b) => b.inPlay()) <= 0) {
+    } else if (balls.filter((b) => b.inPlay()).length === 0) {
       if (levelManager.getLevel() === 1) {
         levelManager.setMissedFirstBubble();
       }
@@ -493,12 +534,13 @@ function onMiss() {
 }
 
 function onTutorialPop() {
-  if (balls.filter((b) => b.inPlay()) <= 0) {
+  if (balls.filter((b) => b.inPlay()).length === 0) {
     tutorialManager.advance();
   }
 }
 
 function onGameEnd() {
+  clearTimeout(showInterstitialTimeout);
   audioManager.playLose();
   levelManager.onGameOver();
 }

--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ animate((deltaTime) => {
       },
       defaultMessage: (msElapsed) => {
         scoreDisplay.draw(deltaTime);
-        shareImageManager.draw(deltaTime);
+        shareImageManager.draw(deltaTime, msElapsed);
         interstitialButtonManager.draw(deltaTime, msElapsed, {
           delay: 960,
           isSharable: true,
@@ -428,7 +428,7 @@ animate((deltaTime) => {
       },
       endGameMessage: (msElapsed) => {
         scoreDisplay.draw(deltaTime);
-        shareImageManager.draw(deltaTime);
+        shareImageManager.draw(deltaTime, msElapsed);
         interstitialButtonManager.draw(deltaTime, msElapsed, {
           delay: 1920,
           text: "Try Again",
@@ -437,7 +437,7 @@ animate((deltaTime) => {
       },
       reachedEndOfGameMessage: (msElapsed) => {
         scoreDisplay.draw(deltaTime);
-        shareImageManager.draw(deltaTime);
+        shareImageManager.draw(deltaTime, msElapsed);
         interstitialButtonManager.draw(deltaTime, msElapsed, {
           delay: 1920,
           text: "Play Again",

--- a/index.js
+++ b/index.js
@@ -167,8 +167,12 @@ canvasManager.getElement().addEventListener("pointerdown", (e) => {
   } else {
     // Capture the pointer so a drag that ends outside the canvas still
     // delivers pointerup here. Without it the pointer is never removed and its
-    // slingshot preview stays on screen.
-    canvasManager.getElement().setPointerCapture(pointerId);
+    // slingshot preview stays on screen. This throws if the pointer is already
+    // gone by the time the queued event is handled, which is harmless — but it
+    // must not stop the gesture below from being registered.
+    try {
+      canvasManager.getElement().setPointerCapture(pointerId);
+    } catch (e) {}
 
     activePointers.push(
       makeActivePointer(

--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ const interstitialButtonManager = makeInterstitialButtonManager(canvasManager);
 const interstitialText = makeTextBlock(
   canvasManager,
   {
-    xPos: canvasManager.getWidth() / 2,
-    yPos: canvasManager.getHeight() / 2,
+    xPos: () => canvasManager.getWidth() / 2,
+    yPos: () => canvasManager.getHeight() / 2,
     textAlign: "center",
     verticalAlign: "center",
   },

--- a/index.js
+++ b/index.js
@@ -28,10 +28,22 @@ import { makeTutorialManager } from "./tutorial.js";
 import { makeFirework } from "./firework.js";
 import { makeShareImageManager } from "./shareImage.js";
 
+// Anyone can put anything after ?level=, and this runs at import time, so a
+// malformed payload would otherwise take the whole game down with it
+function parsePreviewData(encodedLevel) {
+  if (!encodedLevel) return false;
+
+  try {
+    const parsed = JSON.parse(atob(encodedLevel));
+    return Array.isArray(parsed?.balls) ? parsed : false;
+  } catch (e) {
+    return false;
+  }
+}
+
 const URLParams = new URLSearchParams(window.location.search);
-const previewData =
-  URLParams.get("level") && JSON.parse(atob(URLParams.get("level")));
-const previewDataPresent = !!window.location.search && previewData;
+const previewData = parsePreviewData(URLParams.get("level"));
+const previewDataPresent = !!previewData;
 
 if (previewDataPresent) {
   const previewTitle = `Bubbles! - “${previewData.name}”`;

--- a/index.js
+++ b/index.js
@@ -284,19 +284,29 @@ const detectCollisionsForGameObjects = () => {
   // Run collision detection on bubbles and bounce bubbles off eachother
   // Run collision detection on blasts + slingshots and pop colliding bubbles
   const ballsInPlay = balls.filter((b) => b.inPlay());
-  ballsInPlay.forEach((ballA) => {
-    ballsInPlay.forEach((ballB) => {
-      if (ballA !== ballB) {
-        const collision = checkParticleCollision(ballA, ballB);
-        if (collision[0]) {
-          adjustParticlePositions(ballA, ballB, collision[1]);
-          resolveParticleCollision(ballA, ballB);
-        }
+  const outputsInPlay = pointerTriggerOutput.filter((p) => !p.isGone());
+
+  ballsInPlay.forEach((ballA, indexA) => {
+    // Start past ballA so each pair is handled once per frame. Running both
+    // (A, B) and (B, A) applied the positional correction twice.
+    for (let indexB = indexA + 1; indexB < ballsInPlay.length; indexB++) {
+      const ballB = ballsInPlay[indexB];
+      const collision = checkParticleCollision(ballA, ballB);
+      if (collision[0]) {
+        adjustParticlePositions(ballA, ballB, collision[1]);
+        resolveParticleCollision(ballA, ballB);
       }
-    });
-    pointerTriggerOutput
-      .filter((p) => !p.isGone())
-      .forEach((output) => {
+    }
+
+    // Bubbles wait above the top of the screen before a level starts, and a
+    // maxed blast reaches a radius of 280 — far enough to pop the first queued
+    // row at y -180, which the player can't see yet
+    if (ballA.inViewport()) {
+      outputsInPlay.forEach((output) => {
+        // Once popped, a bubble shouldn't also credit the next output that
+        // happens to overlap it this frame with a combo
+        if (ballA.isPopped()) return;
+
         const collision = checkParticleCollision(ballA, output);
         if (collision[0]) {
           output.isHoldBlast()
@@ -308,6 +318,7 @@ const detectCollisionsForGameObjects = () => {
           audioManager.playSequentialPluck();
         }
       });
+    }
   });
 };
 
@@ -486,7 +497,12 @@ function handleGameClick(currentTapPosition, ballAtPointOfInitialTap) {
     balls.filter((b) => b.inPlay() && b.inViewport()),
     currentTapPosition
   );
-  const collidingBall = ballAtPointOfInitialTap || collisionOnPointerUp;
+  // The bubble found on pointerdown may have been popped by a blast in the
+  // meantime, in which case tapping it shouldn't count as popping it again
+  const collidingBall =
+    ballAtPointOfInitialTap && ballAtPointOfInitialTap.inPlay()
+      ? ballAtPointOfInitialTap
+      : collisionOnPointerUp;
 
   if (collidingBall) {
     scoreStore.recordTap(currentTapPosition, 1, collidingBall.getFill());

--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ import { makeTutorialManager } from "./tutorial.js";
 import { makeFirework } from "./firework.js";
 import { makeShareImageManager } from "./shareImage.js";
 
-// Anyone can put anything after ?level=, and this runs at import time, so a
-// malformed payload would otherwise take the whole game down with it
 function parsePreviewData(encodedLevel) {
   if (!encodedLevel) return false;
 
@@ -143,10 +141,6 @@ function resetOngoingVisuals() {
   ripples = [];
 }
 
-// The last level and the missed-first-bubble screen both offer a restart
-// rather than a next level, so every way of dismissing an interstitial has to
-// route through here. Advancing off the last level walks past the end of the
-// level data.
 function advanceFromInterstitial() {
   levelManager.isGameOver() ||
   levelManager.isLastLevel() ||
@@ -165,11 +159,6 @@ canvasManager.getElement().addEventListener("pointerdown", (e) => {
       shareImageManager.share
     );
   } else {
-    // Capture the pointer so a drag that ends outside the canvas still
-    // delivers pointerup here. Without it the pointer is never removed and its
-    // slingshot preview stays on screen. This throws if the pointer is already
-    // gone by the time the queued event is handled, which is harmless — but it
-    // must not stop the gesture below from being registered.
     try {
       canvasManager.getElement().setPointerCapture(pointerId);
     } catch (e) {}
@@ -213,9 +202,6 @@ canvasManager.getElement().addEventListener("pointerup", (e) => {
   e.preventDefault();
 });
 
-// The browser can take a pointer away mid-gesture, e.g. a system swipe or a
-// touch it decides belongs to something else. Drop it rather than leaving it
-// active and drawing forever.
 canvasManager.getElement().addEventListener("pointercancel", (e) => {
   activePointers = activePointers.filter(
     (pointer) => e.pointerId !== pointer.getId()
@@ -238,8 +224,6 @@ canvasManager.getElement().addEventListener("pointermove", (e) => {
 document.addEventListener("keydown", ({ key }) => {
   const validKey = key === " " || key === "Enter";
 
-  // Gated on the button's own delay so the keyboard can't skip an interstitial
-  // before its button is live
   if (
     validKey &&
     levelManager.isInterstitialShowing() &&
@@ -303,8 +287,6 @@ const detectCollisionsForGameObjects = () => {
   const outputsInPlay = pointerTriggerOutput.filter((p) => !p.isGone());
 
   ballsInPlay.forEach((ballA, indexA) => {
-    // Start past ballA so each pair is handled once per frame. Running both
-    // (A, B) and (B, A) applied the positional correction twice.
     for (let indexB = indexA + 1; indexB < ballsInPlay.length; indexB++) {
       const ballB = ballsInPlay[indexB];
       const collision = checkParticleCollision(ballA, ballB);
@@ -314,13 +296,8 @@ const detectCollisionsForGameObjects = () => {
       }
     }
 
-    // Bubbles wait above the top of the screen before a level starts, and a
-    // maxed blast reaches a radius of 280 — far enough to pop the first queued
-    // row at y -180, which the player can't see yet
     if (ballA.inViewport()) {
       outputsInPlay.forEach((output) => {
-        // Once popped, a bubble shouldn't also credit the next output that
-        // happens to overlap it this frame with a combo
         if (ballA.isPopped()) return;
 
         const collision = checkParticleCollision(ballA, output);
@@ -513,8 +490,6 @@ function handleGameClick(currentTapPosition, ballAtPointOfInitialTap) {
     balls.filter((b) => b.inPlay() && b.inViewport()),
     currentTapPosition
   );
-  // The bubble found on pointerdown may have been popped by a blast in the
-  // meantime, in which case tapping it shouldn't count as popping it again
   const collidingBall =
     ballAtPointOfInitialTap && ballAtPointOfInitialTap.inPlay()
       ? ballAtPointOfInitialTap
@@ -537,9 +512,7 @@ function onPointerTrigger(output) {
 
 function onPop() {
   if (balls.filter((b) => b.inPlay()).length === 0) {
-    // Pause before showing interstitial so user can see the final bubble pop.
-    // Tracked so that losing the last life inside this window doesn't let a
-    // stale timer restart the game over screen behind the player.
+    // Pause before showing interstitial so user can see the final bubble pop
     clearTimeout(showInterstitialTimeout);
     showInterstitialTimeout = setTimeout(
       levelManager.showLevelInterstitial,

--- a/interstitialButton.js
+++ b/interstitialButton.js
@@ -262,33 +262,46 @@ function makeShareButton(canvasManager) {
 
 function makeContinueButton(canvasManager, shareButton) {
   const CTX = canvasManager.getContext();
-  const fullWidth = canvasManager.getWidth() - edgeMargin * 2;
-  const partialWidth =
-    canvasManager.getWidth() -
-    edgeMargin * 2 -
-    shareButton.sizes.default.width -
-    spaceBetween;
   const height = 72;
 
   // One color shared by both widths. Rolling separately meant the button
   // changed color the moment a share button appeared beside it.
   const fill = randomColor();
-  const fullButtonPath = new Path2D();
-  const partialButtonPath = new Path2D();
-  fullButtonPath.roundRect(
-    -fullWidth / 2,
-    -height / 2,
-    fullWidth,
-    height,
-    borderRadius
-  );
-  partialButtonPath.roundRect(
-    -partialWidth / 2,
-    -height / 2,
-    partialWidth,
-    height,
-    borderRadius
-  );
+  let fullWidth;
+  let partialWidth;
+  let fullButtonPath;
+  let partialButtonPath;
+
+  // The transforms below read the canvas size live, so the paths have to be
+  // rebuilt to match or the button draws and hit-tests at its old width
+  const buildPaths = () => {
+    fullWidth = canvasManager.getWidth() - edgeMargin * 2;
+    partialWidth =
+      canvasManager.getWidth() -
+      edgeMargin * 2 -
+      shareButton.sizes.default.width -
+      spaceBetween;
+
+    fullButtonPath = new Path2D();
+    partialButtonPath = new Path2D();
+    fullButtonPath.roundRect(
+      -fullWidth / 2,
+      -height / 2,
+      fullWidth,
+      height,
+      borderRadius
+    );
+    partialButtonPath.roundRect(
+      -partialWidth / 2,
+      -height / 2,
+      partialWidth,
+      height,
+      borderRadius
+    );
+  };
+
+  buildPaths();
+  canvasManager.onResize(buildPaths);
 
   return {
     sizes: {
@@ -298,8 +311,12 @@ function makeContinueButton(canvasManager, shareButton) {
             canvasManager.getWidth() / 2,
             canvasManager.getHeight() - edgeMargin - height / 2
           ),
-        path: fullButtonPath,
-        width: fullWidth,
+        get path() {
+          return fullButtonPath;
+        },
+        get width() {
+          return fullWidth;
+        },
         height,
         fill,
       },
@@ -309,8 +326,12 @@ function makeContinueButton(canvasManager, shareButton) {
             edgeMargin + partialWidth / 2,
             canvasManager.getHeight() - edgeMargin - height / 2
           ),
-        path: partialButtonPath,
-        width: partialWidth,
+        get path() {
+          return partialButtonPath;
+        },
+        get width() {
+          return partialWidth;
+        },
         height,
         fill,
       },

--- a/interstitialButton.js
+++ b/interstitialButton.js
@@ -264,16 +264,12 @@ function makeContinueButton(canvasManager, shareButton) {
   const CTX = canvasManager.getContext();
   const height = 72;
 
-  // One color shared by both widths. Rolling separately meant the button
-  // changed color the moment a share button appeared beside it.
   const fill = randomColor();
   let fullWidth;
   let partialWidth;
   let fullButtonPath;
   let partialButtonPath;
 
-  // The transforms below read the canvas size live, so the paths have to be
-  // rebuilt to match or the button draws and hit-tests at its old width
   const buildPaths = () => {
     fullWidth = canvasManager.getWidth() - edgeMargin * 2;
     partialWidth =

--- a/interstitialButton.js
+++ b/interstitialButton.js
@@ -270,6 +270,9 @@ function makeContinueButton(canvasManager, shareButton) {
     spaceBetween;
   const height = 72;
 
+  // One color shared by both widths. Rolling separately meant the button
+  // changed color the moment a share button appeared beside it.
+  const fill = randomColor();
   const fullButtonPath = new Path2D();
   const partialButtonPath = new Path2D();
   fullButtonPath.roundRect(
@@ -298,7 +301,7 @@ function makeContinueButton(canvasManager, shareButton) {
         path: fullButtonPath,
         width: fullWidth,
         height,
-        fill: randomColor(),
+        fill,
       },
       partial: {
         transform: () =>
@@ -309,7 +312,7 @@ function makeContinueButton(canvasManager, shareButton) {
         path: partialButtonPath,
         width: partialWidth,
         height,
-        fill: randomColor(),
+        fill,
       },
     },
     spring: makeSpring(0, {

--- a/interstitialButton.js
+++ b/interstitialButton.js
@@ -218,6 +218,7 @@ export const makeInterstitialButtonManager = (canvasManager) => {
     draw,
     handleClick,
     handleHover,
+    hasDelayPassed: () => !!delayHasPassed,
   };
 };
 

--- a/level.js
+++ b/level.js
@@ -32,8 +32,8 @@ export const makeLevelManager = (
   const levelCountdownText = makeTextBlock(
     canvasManager,
     {
-      xPos: canvasManager.getWidth() / 2,
-      yPos: canvasManager.getHeight() / 2 - circleRadius + 3,
+      xPos: () => canvasManager.getWidth() / 2,
+      yPos: () => canvasManager.getHeight() / 2 - circleRadius + 3,
       textAlign: "center",
       verticalAlign: "center",
       fontSize: 32,
@@ -45,8 +45,8 @@ export const makeLevelManager = (
   const overallParLabel = makeTextBlock(
     canvasManager,
     {
-      xPos: canvasManager.getWidth() / 2,
-      yPos: canvasManager.getHeight() / 2 + circleRadius - 27,
+      xPos: () => canvasManager.getWidth() / 2,
+      yPos: () => canvasManager.getHeight() / 2 + circleRadius - 27,
       textAlign: "center",
       verticalAlign: "center",
       fontWeight: FONT_WEIGHT_BOLD,
@@ -61,8 +61,8 @@ export const makeLevelManager = (
   const overallParText = makeTextBlock(
     canvasManager,
     {
-      xPos: canvasManager.getWidth() / 2,
-      yPos: canvasManager.getHeight() / 2 + circleRadius,
+      xPos: () => canvasManager.getWidth() / 2,
+      yPos: () => canvasManager.getHeight() / 2 + circleRadius,
       textAlign: "center",
       verticalAlign: "center",
       fontSize: 24,

--- a/particle.js
+++ b/particle.js
@@ -28,18 +28,26 @@ export const makeParticle = (
     position.y += Math.min(deltaTimeMultiplier * velocity.y, terminalVelocity);
     velocity.y += deltaTimeMultiplier * gravity;
 
+    // The two axes are checked independently. As one chain, a particle sitting
+    // within its own radius of the left or right edge matched the horizontal
+    // case every frame and the vertical checks were never reached — so a
+    // slingshot released nearly vertically along an edge never got its
+    // onBottomPassed call and was never marked gone, and a bubble hugging a
+    // wall as it fell off the bottom never counted as missed.
     if (position.x > canvasManager.getWidth() + radius) {
       onRightPassed(position, velocity);
     } else if (position.x > canvasManager.getWidth() - radius) {
       onRightTouch(position, velocity);
-    } else if (position.y > canvasManager.getHeight() + radius) {
-      onBottomPassed(position, velocity);
-    } else if (position.y > canvasManager.getHeight() - radius) {
-      onBottomTouch(position, velocity);
     } else if (position.x < -radius) {
       onLeftPassed(position, velocity);
     } else if (position.x < radius) {
       onLeftTouch(position, velocity);
+    }
+
+    if (position.y > canvasManager.getHeight() + radius) {
+      onBottomPassed(position, velocity);
+    } else if (position.y > canvasManager.getHeight() - radius) {
+      onBottomTouch(position, velocity);
     } else if (position.y < -radius) {
       onTopPassed(position, velocity);
     } else if (position.y < radius) {

--- a/particle.js
+++ b/particle.js
@@ -28,12 +28,6 @@ export const makeParticle = (
     position.y += Math.min(deltaTimeMultiplier * velocity.y, terminalVelocity);
     velocity.y += deltaTimeMultiplier * gravity;
 
-    // The two axes are checked independently. As one chain, a particle sitting
-    // within its own radius of the left or right edge matched the horizontal
-    // case every frame and the vertical checks were never reached — so a
-    // slingshot released nearly vertically along an edge never got its
-    // onBottomPassed call and was never marked gone, and a bubble hugging a
-    // wall as it fell off the bottom never counted as missed.
     if (position.x > canvasManager.getWidth() + radius) {
       onRightPassed(position, velocity);
     } else if (position.x > canvasManager.getWidth() - radius) {

--- a/scoreDisplay.js
+++ b/scoreDisplay.js
@@ -385,9 +385,6 @@ export const makeScoreDisplay = (
 
   function drawBlastItem(blast, index) {
     const { popped } = blast;
-    // Clamped like taps and slingshots. Without this the later icons in a long
-    // list are still scaled near zero — invisible — well after the share button
-    // unlocks, so they were missing from shared images.
     const animationDelay = Math.min(index * 88, 880);
     const textHeight = 17.2;
     const scaleIn = transition(
@@ -401,9 +398,6 @@ export const makeScoreDisplay = (
       easeOutQuad
     );
 
-    // The jittered polygon depends only on the blast's power, so generate it
-    // once and keep it on the event. Rebuilding it every frame made the icon
-    // shimmer and made two captures of the same share image differ.
     if (!blast.iconVertices) {
       const blastIconNumVertices = 12;
       const blastIconRadius = transition(

--- a/scoreDisplay.js
+++ b/scoreDisplay.js
@@ -54,7 +54,7 @@ export const makeScoreDisplay = (
 
     if (levelManager.isGameOver() || levelManager.isLastLevel()) {
       stats = {
-        score: scoreStore.overallScoreNumber(),
+        score: scoreStore.overallScoreNumber(!levelManager.isGameOver()),
         taps: scoreStore.getTaps(),
         tapsPopped: scoreStore.sumCategoryLevelEvents("taps").numPopped,
         slingshots: scoreStore.getSlingshots(),

--- a/scoreDisplay.js
+++ b/scoreDisplay.js
@@ -383,20 +383,13 @@ export const makeScoreDisplay = (
     CTX.fillText(`x${popped}`, 30, iconRadius + textHeight / 2);
   }
 
-  function drawBlastItem({ popped, power }, index) {
-    const animationDelay = index * 88;
+  function drawBlastItem(blast, index) {
+    const { popped } = blast;
+    // Clamped like taps and slingshots. Without this the later icons in a long
+    // list are still scaled near zero — invisible — well after the share button
+    // unlocks, so they were missing from shared images.
+    const animationDelay = Math.min(index * 88, 880);
     const textHeight = 17.2;
-    const blastIconNumVertices = 12;
-    const blastIconRadius = transition(
-      iconRadius / 3,
-      iconRadius * 1.2,
-      clampedProgress(0, BLAST_MAX_SIZE, power)
-    );
-    const blastIconJitter = transition(
-      1,
-      2.25,
-      clampedProgress(0, BLAST_MAX_SIZE, power)
-    );
     const scaleIn = transition(
       0,
       1,
@@ -408,19 +401,36 @@ export const makeScoreDisplay = (
       easeOutQuad
     );
 
-    const blastIconVertices = new Array(blastIconNumVertices)
-      .fill()
-      .map((_, index) => {
-        const angle = (index / blastIconNumVertices) * Math.PI * 2;
-        const distance = randomBetween(
-          blastIconRadius - blastIconJitter,
-          blastIconRadius + blastIconJitter
-        );
-        return {
-          x: Math.cos(angle) * distance,
-          y: Math.sin(angle) * distance,
-        };
-      });
+    // The jittered polygon depends only on the blast's power, so generate it
+    // once and keep it on the event. Rebuilding it every frame made the icon
+    // shimmer and made two captures of the same share image differ.
+    if (!blast.iconVertices) {
+      const blastIconNumVertices = 12;
+      const blastIconRadius = transition(
+        iconRadius / 3,
+        iconRadius * 1.2,
+        clampedProgress(0, BLAST_MAX_SIZE, blast.power)
+      );
+      const blastIconJitter = transition(
+        1,
+        2.25,
+        clampedProgress(0, BLAST_MAX_SIZE, blast.power)
+      );
+
+      blast.iconVertices = new Array(blastIconNumVertices)
+        .fill()
+        .map((_, index) => {
+          const angle = (index / blastIconNumVertices) * Math.PI * 2;
+          const distance = randomBetween(
+            blastIconRadius - blastIconJitter,
+            blastIconRadius + blastIconJitter
+          );
+          return {
+            x: Math.cos(angle) * distance,
+            y: Math.sin(angle) * distance,
+          };
+        });
+    }
 
     CTX.save();
     if (popped > 0) {
@@ -434,7 +444,7 @@ export const makeScoreDisplay = (
     CTX.translate(iconRadius, iconRadius);
     CTX.scale(scaleIn, scaleIn);
     CTX.beginPath();
-    blastIconVertices.forEach(({ x, y }, index) => {
+    blast.iconVertices.forEach(({ x, y }, index) => {
       index === 0 ? CTX.moveTo(x, y) : CTX.lineTo(x, y);
     });
     CTX.closePath();

--- a/scoreStore.js
+++ b/scoreStore.js
@@ -39,10 +39,6 @@ export const makeScoreStore = (levelManager) => {
   // ]);
 
   let store;
-  // Projectiles are looked up by this when their pop count is updated. It used
-  // to be the timestamp, which two projectiles released in the same
-  // millisecond -- two fingers, or two blasts timing out on the same frame --
-  // share, so one collected the other's combos.
   let nextEventId = 0;
 
   const reset = () =>
@@ -91,8 +87,6 @@ export const makeScoreStore = (levelManager) => {
       .get("slingshots")
       .findIndex((i) => i.id === id);
 
-    // A projectile can outlive the store that recorded it — resetting the score
-    // store doesn't clear projectiles still in flight
     if (slingshotIndex === -1) return;
 
     const slingshotsCopy = [...store.get("slingshots")];
@@ -180,9 +174,6 @@ export const makeScoreStore = (levelManager) => {
       filteredEvents = store.get(category);
     }
 
-    // Every recorded event stores a `popped` key, including missed bubbles,
-    // which store 0. An empty category therefore sums to 0 rather than
-    // omitting numPopped entirely.
     return {
       data: filteredEvents,
       num: filteredEvents.length,
@@ -221,9 +212,6 @@ export const makeScoreStore = (levelManager) => {
     return numMoves - levelManager.getLevelData().par;
   };
 
-  // `currentLevelPlayed` has no default on purpose: leaving it off silently
-  // gave the end-of-game screens the countdown behavior, which dropped the
-  // final level from the score. Every caller has to say which it wants.
   const overallScoreNumber = (currentLevelPlayed) => {
     // For the level countdown we want to display the overall par before the
     // current level is played e.g. on level 3, we want to display the score of
@@ -231,8 +219,7 @@ export const makeScoreStore = (levelManager) => {
     //
     // For the end-of-game screen we want to display the overall par after the
     // current level has been played e.g. after level 3, we want to display the
-    // score of level 1 + level 2 + level 3. A level ended by a game over was
-    // not completed, so it passes false and contributes neither moves nor par.
+    // score of level 1 + level 2 + level 3.
     const maxLevelReached = currentLevelPlayed
       ? levelManager.getLevel()
       : levelManager.getLevel() - 1;

--- a/scoreStore.js
+++ b/scoreStore.js
@@ -17,15 +17,15 @@ export const makeScoreStore = (levelManager) => {
   //   [
   //     "slingshots",
   //     [
-  //       { timestamp: 1234, level: 1, position: { x: 42, y: 56 }, velocity: { x: 0, y: 0 }, popped: 3, spring: [object], hasShownCombo: false },
-  //       { timestamp: 1234, level: 1, position: { x: 42, y: 56 }, velocity: { x: 0, y: 0 }, popped: 2, spring: [object], hasShownCombo: false }
+  //       { id: 0, timestamp: 1234, level: 1, position: { x: 42, y: 56 }, velocity: { x: 0, y: 0 }, popped: 3, spring: [object], hasShownCombo: false },
+  //       { id: 1, timestamp: 1234, level: 1, position: { x: 42, y: 56 }, velocity: { x: 0, y: 0 }, popped: 2, spring: [object], hasShownCombo: false }
   //     ],
   //   ],
   //   [
   //     "blasts",
   //     [
-  //       { timestamp: 1234, level: 1, position: { x: 42, y: 56 }, power: 123, popped: 2 },
-  //       { timestamp: 1234, level: 1, position: { x: 42, y: 56 }, power: 123, popped: 3 }
+  //       { id: 2, timestamp: 1234, level: 1, position: { x: 42, y: 56 }, power: 123, popped: 2 },
+  //       { id: 3, timestamp: 1234, level: 1, position: { x: 42, y: 56 }, power: 123, popped: 3 }
   //     ],
   //   ],
   //   [
@@ -39,6 +39,11 @@ export const makeScoreStore = (levelManager) => {
   // ]);
 
   let store;
+  // Projectiles are looked up by this when their pop count is updated. It used
+  // to be the timestamp, which two projectiles released in the same
+  // millisecond -- two fingers, or two blasts timing out on the same frame --
+  // share, so one collected the other's combos.
+  let nextEventId = 0;
 
   const reset = () =>
     (store = new Map([
@@ -63,12 +68,13 @@ export const makeScoreStore = (levelManager) => {
   };
 
   const recordSlingshot = (position, velocity, popped) => {
-    const timestamp = Date.now();
+    const id = nextEventId++;
 
     store.set("slingshots", [
       ...store.get("slingshots"),
       {
-        timestamp,
+        id,
+        timestamp: Date.now(),
         level: levelManager.getLevel(),
         position: { ...position },
         velocity: { ...velocity },
@@ -77,13 +83,13 @@ export const makeScoreStore = (levelManager) => {
       },
     ]);
 
-    return timestamp;
+    return id;
   };
 
-  const updateSlingshot = (timestamp, popped) => {
+  const updateSlingshot = (id, popped) => {
     const slingshotIndex = store
       .get("slingshots")
-      .findIndex((i) => i.timestamp === timestamp);
+      .findIndex((i) => i.id === id);
 
     // A projectile can outlive the store that recorded it — resetting the score
     // store doesn't clear projectiles still in flight
@@ -112,12 +118,13 @@ export const makeScoreStore = (levelManager) => {
   };
 
   const recordBlast = (position, power, popped) => {
-    const timestamp = Date.now();
+    const id = nextEventId++;
 
     store.set("blasts", [
       ...store.get("blasts"),
       {
-        timestamp,
+        id,
+        timestamp: Date.now(),
         level: levelManager.getLevel(),
         position,
         power,
@@ -126,13 +133,11 @@ export const makeScoreStore = (levelManager) => {
       },
     ]);
 
-    return timestamp;
+    return id;
   };
 
-  const updateBlast = (timestamp, popped) => {
-    const blastIndex = store
-      .get("blasts")
-      .findIndex((i) => i.timestamp === timestamp);
+  const updateBlast = (id, popped) => {
+    const blastIndex = store.get("blasts").findIndex((i) => i.id === id);
 
     if (blastIndex === -1) return;
 

--- a/scoreStore.js
+++ b/scoreStore.js
@@ -85,6 +85,10 @@ export const makeScoreStore = (levelManager) => {
       .get("slingshots")
       .findIndex((i) => i.timestamp === timestamp);
 
+    // A projectile can outlive the store that recorded it — resetting the score
+    // store doesn't clear projectiles still in flight
+    if (slingshotIndex === -1) return;
+
     const slingshotsCopy = [...store.get("slingshots")];
 
     slingshotsCopy[slingshotIndex].popped = popped;
@@ -129,6 +133,8 @@ export const makeScoreStore = (levelManager) => {
     const blastIndex = store
       .get("blasts")
       .findIndex((i) => i.timestamp === timestamp);
+
+    if (blastIndex === -1) return;
 
     const blastsCopy = [...store.get("blasts")];
 

--- a/scoreStore.js
+++ b/scoreStore.js
@@ -158,8 +158,6 @@ export const makeScoreStore = (levelManager) => {
       { timestamp: Date.now(), level: levelManager.getLevel(), popped: 0 },
     ]);
 
-  const hasPoppedKey = (name) => store.get(name).some((o) => "popped" in o);
-
   const sumCategoryLevelEvents = (category, passedLevel = null) => {
     let filteredEvents;
 
@@ -171,16 +169,14 @@ export const makeScoreStore = (levelManager) => {
       filteredEvents = store.get(category);
     }
 
-    return hasPoppedKey(category)
-      ? {
-          data: filteredEvents,
-          num: filteredEvents.length,
-          numPopped: filteredEvents.reduce(
-            (acc, { popped }) => acc + popped,
-            0
-          ),
-        }
-      : { num: filteredEvents.length };
+    // Every recorded event stores a `popped` key, including missed bubbles,
+    // which store 0. An empty category therefore sums to 0 rather than
+    // omitting numPopped entirely.
+    return {
+      data: filteredEvents,
+      num: filteredEvents.length,
+      numPopped: filteredEvents.reduce((acc, { popped }) => acc + popped, 0),
+    };
   };
 
   const sumPopped = (passedLevel = null) => {
@@ -214,14 +210,18 @@ export const makeScoreStore = (levelManager) => {
     return numMoves - levelManager.getLevelData().par;
   };
 
-  const overallScoreNumber = (currentLevelPlayed = false) => {
+  // `currentLevelPlayed` has no default on purpose: leaving it off silently
+  // gave the end-of-game screens the countdown behavior, which dropped the
+  // final level from the score. Every caller has to say which it wants.
+  const overallScoreNumber = (currentLevelPlayed) => {
     // For the level countdown we want to display the overall par before the
     // current level is played e.g. on level 3, we want to display the score of
     // level 1 + level 2.
     //
     // For the end-of-game screen we want to display the overall par after the
     // current level has been played e.g. after level 3, we want to display the
-    // score of level 1 + level 2 + level 3.
+    // score of level 1 + level 2 + level 3. A level ended by a game over was
+    // not completed, so it passes false and contributes neither moves nor par.
     const maxLevelReached = currentLevelPlayed
       ? levelManager.getLevel()
       : levelManager.getLevel() - 1;

--- a/shareImage.js
+++ b/shareImage.js
@@ -70,7 +70,10 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
     // just the header on black. getCurrentHeight() is null until the score
     // display has drawn once, and a null height would floor the bitmap to 0.
     const settledHeight = shareImageScoreDisplay.getCurrentHeight();
-    if (settledHeight && shareImageCanvasManager.getHeight() !== settledHeight) {
+    if (
+      settledHeight &&
+      shareImageCanvasManager.getHeight() !== settledHeight
+    ) {
       shareImageCanvasManager.setCanvasSize({ height: settledHeight });
     }
 

--- a/shareImage.js
+++ b/shareImage.js
@@ -3,6 +3,20 @@ import { makeScoreDisplay } from "./scoreDisplay.js";
 import { background, yellow } from "./colors.js";
 import { FONT_WEIGHT_BOLD, FONT_WEIGHT_NORMAL, FONT } from "./constants.js";
 
+// The share image is encoded ahead of the tap so that share() can hand it to
+// navigator.share() without awaiting anything. Snapshots are taken at moments
+// where the score display has settled:
+//
+// * 880ms: after the 816ms slide-up finishes (getCurrentHeight() reports the
+//   settled height, so capturing mid-slide clips the bottom) and before the
+//   mid-game share button unlocks at 960ms.
+// * 1900ms: just before the end-of-game share button unlocks at 1920ms.
+// * 3800ms: after the longest icon animation, the missed-tap ripple.
+//
+// The first two are pinned to the `delay` values in index.js. If those move,
+// these move.
+const CAPTURE_DELAYS = [880, 1900, 3800];
+
 export const makeShareImageManager = (scoreStore, levelManager) => {
   const shareImageCanvasManager = makeOffscreenCanvas({
     width: 400,
@@ -18,12 +32,48 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
   );
 
   const CTX = shareImageCanvasManager.getContext();
+  let captureStart = Date.now();
+  let numCapturesTaken = 0;
+  let captureToken = 0;
+  let shareFile = false;
 
   const update = () => {
     shareImageScoreDisplay.update();
+    captureStart = Date.now();
+    numCapturesTaken = 0;
+    // Discard the previous interstitial's image, and make any encode still in
+    // flight for it a no-op
+    shareFile = false;
+    captureToken++;
+  };
+
+  // convertToBlob copies the bitmap synchronously and encodes off-thread, so
+  // calling this at the end of draw() captures the frame just painted
+  const captureShareImage = () => {
+    const token = captureToken;
+
+    shareImageCanvasManager
+      .getElement()
+      .convertToBlob({ type: "image/jpeg", quality: 0.8 })
+      .then((blob) => {
+        if (token === captureToken) {
+          shareFile = new File([blob], "bubbles.jpeg", { type: "image/jpeg" });
+        }
+      })
+      .catch(() => {});
   };
 
   const draw = (deltaTime) => {
+    // Resize before painting anything. Changing the height of an OffscreenCanvas
+    // clears its bitmap and resets the context, so resizing partway through the
+    // frame wipes everything drawn so far — which used to leave the image as
+    // just the header on black. getCurrentHeight() is null until the score
+    // display has drawn once, and a null height would floor the bitmap to 0.
+    const settledHeight = shareImageScoreDisplay.getCurrentHeight();
+    if (settledHeight && shareImageCanvasManager.getHeight() !== settledHeight) {
+      shareImageCanvasManager.setCanvasSize({ height: settledHeight });
+    }
+
     CTX.save();
     CTX.fillStyle = background;
     CTX.fillRect(
@@ -35,15 +85,6 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
     CTX.restore();
 
     shareImageScoreDisplay.draw(deltaTime);
-
-    if (
-      shareImageCanvasManager.getHeight() !==
-      shareImageScoreDisplay.getCurrentHeight()
-    ) {
-      shareImageCanvasManager.setCanvasSize({
-        height: shareImageScoreDisplay.getCurrentHeight(),
-      });
-    }
 
     CTX.save();
 
@@ -63,6 +104,20 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
     );
 
     CTX.restore();
+
+    if (
+      numCapturesTaken < CAPTURE_DELAYS.length &&
+      Date.now() - captureStart > CAPTURE_DELAYS[numCapturesTaken]
+    ) {
+      numCapturesTaken++;
+      captureShareImage();
+    }
+  };
+
+  const copyShareText = (shareText) => {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(shareText).catch(() => {});
+    }
   };
 
   const share = () => {
@@ -82,7 +137,7 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
 ${stats.score > 0 || stats.score < 0 ? `${Math.abs(stats.score)} ` : ""}${
       stats.score > 0 ? "over" : stats.score < 0 ? "under" : "Even with"
     } par overall
-  
+
 https://ehmorris.com/bubbles
 
 👆 Tapped ${stats.taps.length} times: ${stats.tapsPopped} ${
@@ -98,23 +153,41 @@ https://ehmorris.com/bubbles
     }
 `;
 
-    shareImageCanvasManager
-      .getElement()
-      .convertToBlob({ type: "image/jpeg", quality: 0.8 })
-      .then((blob) => {
-        const data = {
-          files: [
-            new File([blob], "bubbles.jpeg", {
-              type: "image/jpeg",
-            }),
-          ],
-          text: shareText,
-        };
+    // Everything from here has to run in the same turn as the pointer event.
+    // Awaiting the image encode first spends the transient user activation, and
+    // iOS Safari then rejects navigator.share() — the first tap did nothing and
+    // the second worked only because the encoder was warm enough to land inside
+    // the activation window.
+    const fileData = shareFile
+      ? { files: [shareFile], text: shareText }
+      : false;
+    const textData = { text: shareText };
 
-        navigator.canShare && navigator.canShare(data)
-          ? navigator.share(data)
-          : navigator.clipboard.writeText(shareText);
+    // Fall back through image + text, then text alone, then the clipboard. The
+    // image is only missing if the tab was backgrounded so the capture never
+    // ran, and text-only sharing beats silently copying (desktop Chrome can't
+    // share files but does have a share sheet).
+    const shareData =
+      fileData && navigator.canShare && navigator.canShare(fileData)
+        ? fileData
+        : navigator.share
+        ? textData
+        : false;
+
+    if (!shareData) {
+      copyShareText(shareText);
+      return;
+    }
+
+    try {
+      navigator.share(shareData).catch((error) => {
+        // Dismissing the share sheet rejects with AbortError. The player
+        // changed their mind, so there's nothing to recover from.
+        if (error.name !== "AbortError") copyShareText(shareText);
       });
+    } catch (e) {
+      copyShareText(shareText);
+    }
   };
 
   return { update, draw, share };

--- a/shareImage.js
+++ b/shareImage.js
@@ -20,34 +20,35 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
   );
 
   const CTX = shareImageCanvasManager.getContext();
-  let captureStart = Date.now();
   let numCapturesTaken = 0;
+  let lastCaptureUsed = -1;
   let captureToken = 0;
   let shareFile = false;
 
   const update = () => {
     shareImageScoreDisplay.update();
-    captureStart = Date.now();
     numCapturesTaken = 0;
+    lastCaptureUsed = -1;
     shareFile = false;
     captureToken++;
   };
 
-  const captureShareImage = () => {
+  const captureShareImage = (sequence) => {
     const token = captureToken;
 
     shareImageCanvasManager
       .getElement()
       .convertToBlob({ type: "image/jpeg", quality: 0.8 })
       .then((blob) => {
-        if (token === captureToken) {
+        if (token === captureToken && sequence > lastCaptureUsed) {
+          lastCaptureUsed = sequence;
           shareFile = new File([blob], "bubbles.jpeg", { type: "image/jpeg" });
         }
       })
       .catch(() => {});
   };
 
-  const draw = (deltaTime) => {
+  const draw = (deltaTime, msElapsed) => {
     const settledHeight = shareImageScoreDisplay.getCurrentHeight();
     if (
       settledHeight &&
@@ -89,10 +90,9 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
 
     if (
       numCapturesTaken < CAPTURE_DELAYS.length &&
-      Date.now() - captureStart > CAPTURE_DELAYS[numCapturesTaken]
+      msElapsed > CAPTURE_DELAYS[numCapturesTaken]
     ) {
-      numCapturesTaken++;
-      captureShareImage();
+      captureShareImage(numCapturesTaken++);
     }
   };
 

--- a/shareImage.js
+++ b/shareImage.js
@@ -3,18 +3,6 @@ import { makeScoreDisplay } from "./scoreDisplay.js";
 import { background, yellow } from "./colors.js";
 import { FONT_WEIGHT_BOLD, FONT_WEIGHT_NORMAL, FONT } from "./constants.js";
 
-// The share image is encoded ahead of the tap so that share() can hand it to
-// navigator.share() without awaiting anything. Snapshots are taken at moments
-// where the score display has settled:
-//
-// * 880ms: after the 816ms slide-up finishes (getCurrentHeight() reports the
-//   settled height, so capturing mid-slide clips the bottom) and before the
-//   mid-game share button unlocks at 960ms.
-// * 1900ms: just before the end-of-game share button unlocks at 1920ms.
-// * 3800ms: after the longest icon animation, the missed-tap ripple.
-//
-// The first two are pinned to the `delay` values in index.js. If those move,
-// these move.
 const CAPTURE_DELAYS = [880, 1900, 3800];
 
 export const makeShareImageManager = (scoreStore, levelManager) => {
@@ -41,14 +29,10 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
     shareImageScoreDisplay.update();
     captureStart = Date.now();
     numCapturesTaken = 0;
-    // Discard the previous interstitial's image, and make any encode still in
-    // flight for it a no-op
     shareFile = false;
     captureToken++;
   };
 
-  // convertToBlob copies the bitmap synchronously and encodes off-thread, so
-  // calling this at the end of draw() captures the frame just painted
   const captureShareImage = () => {
     const token = captureToken;
 
@@ -64,11 +48,6 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
   };
 
   const draw = (deltaTime) => {
-    // Resize before painting anything. Changing the height of an OffscreenCanvas
-    // clears its bitmap and resets the context, so resizing partway through the
-    // frame wipes everything drawn so far — which used to leave the image as
-    // just the header on black. getCurrentHeight() is null until the score
-    // display has drawn once, and a null height would floor the bitmap to 0.
     const settledHeight = shareImageScoreDisplay.getCurrentHeight();
     if (
       settledHeight &&
@@ -156,20 +135,11 @@ https://ehmorris.com/bubbles
     }
 `;
 
-    // Everything from here has to run in the same turn as the pointer event.
-    // Awaiting the image encode first spends the transient user activation, and
-    // iOS Safari then rejects navigator.share() — the first tap did nothing and
-    // the second worked only because the encoder was warm enough to land inside
-    // the activation window.
     const fileData = shareFile
       ? { files: [shareFile], text: shareText }
       : false;
     const textData = { text: shareText };
 
-    // Fall back through image + text, then text alone, then the clipboard. The
-    // image is only missing if the tab was backgrounded so the capture never
-    // ran, and text-only sharing beats silently copying (desktop Chrome can't
-    // share files but does have a share sheet).
     const shareData =
       fileData && navigator.canShare && navigator.canShare(fileData)
         ? fileData
@@ -184,8 +154,6 @@ https://ehmorris.com/bubbles
 
     try {
       navigator.share(shareData).catch((error) => {
-        // Dismissing the share sheet rejects with AbortError. The player
-        // changed their mind, so there's nothing to recover from.
         if (error.name !== "AbortError") copyShareText(shareText);
       });
     } catch (e) {

--- a/shareImage.js
+++ b/shareImage.js
@@ -67,7 +67,7 @@ export const makeShareImageManager = (scoreStore, levelManager) => {
 
   const share = () => {
     const stats = {
-      score: scoreStore.overallScoreNumber(),
+      score: scoreStore.overallScoreNumber(!levelManager.isGameOver()),
       taps: scoreStore.getTaps(),
       tapsPopped: scoreStore.sumCategoryLevelEvents("taps").numPopped,
       slingshots: scoreStore.getSlingshots(),

--- a/slingshot.js
+++ b/slingshot.js
@@ -77,11 +77,6 @@ export const makeSlingshot = (
       (startPosition.y - endPosition.y) ** 2
   );
 
-  // TODO something wrong here:
-  // * Point slingshot down and left
-  // * Pull back far
-  // * Release
-  // * Slingshot has the wrong angle
   const startVelocity = getVelocityFromSpeedAndHeading(
     distance / 10,
     getHeadingInRadsFromTwoPoints(startPosition, endPosition)
@@ -96,6 +91,12 @@ export const makeSlingshot = (
     startPosition: { ...endPosition },
     startVelocity,
     gravity: GRAVITY,
+    // particle.update caps how far a particle moves down each frame but never
+    // caps how far it moves sideways, so a fast downward shot crawls down while
+    // still racing across — a slingshot aimed 45° down-left left at nearly 15°
+    // once pulled far enough. Its speed is already set at launch, so don't cap
+    // it. Pop pieces and sparks opt out the same way.
+    terminalVelocity: Infinity,
     onRightPassed: onLeaveScreen,
     onBottomPassed: onLeaveScreen,
     onLeftPassed: onLeaveScreen,

--- a/slingshot.js
+++ b/slingshot.js
@@ -102,7 +102,7 @@ export const makeSlingshot = (
     onTopPassed: onLeaveScreen,
   });
 
-  let comboTrackerTimestamp = scoreStore.recordSlingshot(
+  let comboTrackerId = scoreStore.recordSlingshot(
     baseParticle.getPosition(),
     startVelocity,
     numCollisions
@@ -114,7 +114,7 @@ export const makeSlingshot = (
 
   const logCollision = () => {
     numCollisions++;
-    scoreStore.updateSlingshot(comboTrackerTimestamp, numCollisions);
+    scoreStore.updateSlingshot(comboTrackerId, numCollisions);
   };
 
   const draw = (deltaTime) => {

--- a/slingshot.js
+++ b/slingshot.js
@@ -91,11 +91,6 @@ export const makeSlingshot = (
     startPosition: { ...endPosition },
     startVelocity,
     gravity: GRAVITY,
-    // particle.update caps how far a particle moves down each frame but never
-    // caps how far it moves sideways, so a fast downward shot crawls down while
-    // still racing across — a slingshot aimed 45° down-left left at nearly 15°
-    // once pulled far enough. Its speed is already set at launch, so don't cap
-    // it. Pop pieces and sparks opt out the same way.
     terminalVelocity: Infinity,
     onRightPassed: onLeaveScreen,
     onBottomPassed: onLeaveScreen,

--- a/textBlock.js
+++ b/textBlock.js
@@ -26,6 +26,13 @@ export const makeTextBlock = (
     verticalAlign === "center" ? (linesArray.length / 2) * lineHeight : 0;
   let yPos = initialYPos;
 
+  // Positions derived from the canvas size are passed as functions so they
+  // stay correct after a resize or an orientation change
+  const resolvePosition = (position) =>
+    typeof position === "function" ? position() : position;
+  const getXPos = () => resolvePosition(xPos);
+  const getYPos = () => resolvePosition(yPos);
+
   const positionSpring = makeSpring(lineHeight, {
     stiffness: 120,
     damping: 13,
@@ -50,10 +57,11 @@ export const makeTextBlock = (
 
   const getBoundingBox = () => {
     const leading = lineHeight - fontSize;
+    const top = getYPos() - verticalOffset + leading;
 
     return {
-      top: yPos - verticalOffset + leading,
-      bottom: yPos - verticalOffset + leading + lineHeight * linesArray.length,
+      top,
+      bottom: top + lineHeight * linesArray.length,
     };
   };
 
@@ -66,7 +74,8 @@ export const makeTextBlock = (
       CTX.fillStyle = fill;
       CTX.textAlign = textAlign;
       CTX.letterSpacing = letterSpacing;
-      CTX.translate(xPos, yPos - verticalOffset);
+      const currentXPos = getXPos();
+      CTX.translate(currentXPos, getYPos() - verticalOffset);
       linesArray.forEach((line, index) => {
         const lineYPos = (index + 1) * lineHeight;
 
@@ -75,7 +84,7 @@ export const makeTextBlock = (
         // Draw clipping mask
         CTX.beginPath();
         CTX.rect(
-          -xPos,
+          -currentXPos,
           lineYPos - fontSize,
           canvasManager.getWidth(),
           lineHeight

--- a/textBlock.js
+++ b/textBlock.js
@@ -26,8 +26,6 @@ export const makeTextBlock = (
     verticalAlign === "center" ? (linesArray.length / 2) * lineHeight : 0;
   let yPos = initialYPos;
 
-  // Positions derived from the canvas size are passed as functions so they
-  // stay correct after a resize or an orientation change
   const resolvePosition = (position) =>
     typeof position === "function" ? position() : position;
   const getXPos = () => resolvePosition(xPos);

--- a/tutorial.js
+++ b/tutorial.js
@@ -20,8 +20,8 @@ export const makeTutorialManager = (
   const textManager = makeTextBlock(
     canvasManager,
     {
-      xPos: canvasManager.getWidth() / 2,
-      yPos: canvasManager.getHeight() / 2 - canvasManager.getHeight() / 4,
+      xPos: () => canvasManager.getWidth() / 2,
+      yPos: () => canvasManager.getHeight() / 2 - canvasManager.getHeight() / 4,
       textAlign: "center",
       verticalAlign: "center",
     },
@@ -148,7 +148,8 @@ function makeTutorialData(canvasManager, textManager, getStepStarted) {
   return [
     {
       initialText: ["Pop this"],
-      textYPos: canvasManager.getHeight() / 2 - canvasManager.getHeight() / 4,
+      textYPos: () =>
+        canvasManager.getHeight() / 2 - canvasManager.getHeight() / 4,
       draw: () => {
         drawCenteredDownwardsArrow(
           canvasManager,
@@ -172,21 +173,22 @@ function makeTutorialData(canvasManager, textManager, getStepStarted) {
     {
       timeout: 1800,
       initialText: ["Nice! But…"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       timeout: 2300,
       initialText: ["What if there are more?"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       initialText: ["Hold down in", "the center"],
       confirmationText: ["Now let go!"],
-      textYPos: canvasManager.getHeight() / 2 - canvasManager.getHeight() / 3,
+      textYPos: () =>
+        canvasManager.getHeight() / 2 - canvasManager.getHeight() / 3,
       draw: () => {
         drawCenteredDownwardsArrow(
           canvasManager,
@@ -231,28 +233,28 @@ function makeTutorialData(canvasManager, textManager, getStepStarted) {
     {
       timeout: 1100,
       initialText: ["Boom!"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       timeout: 2000,
       initialText: ["That’s called a “blast”"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       timeout: 1900,
       initialText: ["One last thing…"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       initialText: ["Drag down", "", "Start right here"],
       confirmationText: ["Let go!"],
-      textYPos: canvasManager.getHeight() / 2,
+      textYPos: () => canvasManager.getHeight() / 2,
       balls: [
         {
           position: {
@@ -281,14 +283,14 @@ function makeTutorialData(canvasManager, textManager, getStepStarted) {
     {
       timeout: 2600,
       initialText: ["Those are all the", "ways to pop bubbles"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },
     {
       timeout: 1800,
       initialText: ["You’re ready to play"],
-      textYPos: canvasManager.getHeight() / 2 - 8,
+      textYPos: () => canvasManager.getHeight() / 2 - 8,
       balls: [],
       allowedGestures: [],
     },

--- a/tutorial.js
+++ b/tutorial.js
@@ -27,9 +27,6 @@ export const makeTutorialManager = (
     },
     []
   );
-  // Passed as a getter: the data is built once, so a captured stepStarted
-  // stayed at the construction time and later steps' arrows skipped their
-  // animation entirely
   const tutorialData = makeTutorialData(
     canvasManager,
     textManager,

--- a/tutorial.js
+++ b/tutorial.js
@@ -27,10 +27,13 @@ export const makeTutorialManager = (
     },
     []
   );
+  // Passed as a getter: the data is built once, so a captured stepStarted
+  // stayed at the construction time and later steps' arrows skipped their
+  // animation entirely
   const tutorialData = makeTutorialData(
     canvasManager,
     textManager,
-    stepStarted
+    () => stepStarted
   );
   textManager.updateLines(tutorialData[0].initialText);
 
@@ -141,7 +144,7 @@ export const makeTutorialManager = (
   };
 };
 
-function makeTutorialData(canvasManager, textManager, stepStarted) {
+function makeTutorialData(canvasManager, textManager, getStepStarted) {
   return [
     {
       initialText: ["Pop this"],
@@ -151,7 +154,7 @@ function makeTutorialData(canvasManager, textManager, stepStarted) {
           canvasManager,
           textManager.getBoundingBox().bottom + 12,
           canvasManager.getHeight() / 2 - BUBBLE_RADIUS - 32,
-          stepStarted,
+          getStepStarted(),
           white
         );
       },
@@ -189,7 +192,7 @@ function makeTutorialData(canvasManager, textManager, stepStarted) {
           canvasManager,
           textManager.getBoundingBox().bottom + 12,
           canvasManager.getHeight() / 2,
-          stepStarted,
+          getStepStarted(),
           white
         );
       },


### PR DESCRIPTION
(AI generated)

# Fix the share sheet needing two taps on iOS, and the bugs found auditing around it

## Why

The share sheet often didn't open until the share button was tapped twice on iOS. Tracking
that down turned into a full read of the codebase, so this also carries the other bugs that
came out of it — including three the repo already knew about and said so out loud:

- `scoreStore.js` documents that the end-of-game screen must pass `currentLevelPlayed: true`.
  Neither end-screen caller did.
- Commit `3456af7`, *"Only check for collisions for in-view in-play bubbles"*, added the
  `inViewport()` filter to both `findBallAtPoint` calls but not to the collision loop.
- `builder/index.js` had `// This is triggering an error at L206 for some reason` above the
  arrow-key handler.
- `slingshot.js` had a `TODO` with repro steps for a wrong launch angle.

## The iOS bug

`share()` called `convertToBlob()` and then `navigator.share()` from inside the resulting
`.then()`. `navigator.share()` requires transient user activation, and WebKit doesn't hold it
across a slow JPEG encode — so the first tap rejected with `NotAllowedError` into a promise
with no `.catch()`, silently. The second tap worked because the encoder was warm and the
callback landed inside the window.

The image is now encoded ahead of the tap, during `draw()`, at 880/1900/3800ms — after the
816ms slide-up settles and pinned either side of the 960ms and 1920ms button unlocks.
`share()` reads the cached `File` and calls `navigator.share()` in the same turn as the
pointer event, with no `await` anywhere on that path. A monotonic token discards any encode
still in flight from a previous interstitial.

## Scoring

- **The end screens dropped the level you just played** from the "N over/under par overall"
  number, on screen and in the shared text, while the icon grids right below counted every
  level. Both callers are now explicit, and the parameter lost its default so this can't
  regress silently. A level ended by a game over still contributes nothing, since it wasn't
  completed.
- **`Tapped 0 times: undefined hits, NaN misses`** in the shared text for anyone who cleared
  levels without tapping. `hasPoppedKey` used `.some()`, which is false for an empty array, so
  the category returned no `numPopped` at all. Removed — every event records a `popped` key.
- **Projectiles were keyed by `Date.now()`.** Two released in the same millisecond — two
  fingers, or two hold blasts timing out on the same frame — shared a handle, so one collected
  the other's combos and the other showed `x0`. They now get a unique id.

## The share image itself

- **It could be almost entirely black.** The canvas resized *after* the content was painted,
  and setting `OffscreenCanvas.height` clears the bitmap, so the first frame of every
  interstitial was just the header on black. Resize happens first now.
- Blast icons were **re-randomised every frame** and their animation delay was **unclamped**,
  unlike taps and slingshots — so late icons were still invisible when the button unlocked,
  and two captures of the same run never matched.
- Failure paths that had none: `AbortError` from dismissing the sheet is no longer an
  unhandled rejection, sharing degrades image+text → text-only → clipboard so desktop Chrome
  gets a real share sheet instead of a silent copy, and `navigator.clipboard` is checked
  before use.

## Gameplay

- **Space/Enter took a different branch than clicking the button.** On "You beat all levels!"
  it advanced past level 16, so `getLevelDataByNumber` returned undefined and reading `.par`
  threw — before `interstitialShowing` was cleared, leaving the screen stuck and incrementing
  the level on every further press. On "Whoops, try to get that bubble" it advanced to level 2
  with `missedFirstBubble` still set, and since only `reset()` clears that flag, every later
  interstitial rendered the retry screen — the run could never progress again. Both paths go
  through one function now.
- **Maxed blasts popped bubbles still queued above the screen.** The first queued row sits at
  y −180 and a maxed blast reaches a radius of 280.
- **`ball.pop()` wasn't idempotent.** Two overlapping blasts popped the same bubble twice,
  restarting its animation, firing `onPop` twice and crediting both with a combo. A tap on a
  bubble a blast already popped counted the pop a second time.
- **Slingshots released near a screen edge lived forever.** `particle.update` was one
  `else if` chain, so a particle within its own radius of the left or right edge matched the
  horizontal case every frame and the vertical checks were never reached. Slingshots only
  register the `*Passed` handlers, so one released nearly vertically along an edge was never
  marked gone — retained across every level for the rest of the session, drawn and
  collision-checked every frame. The axes are checked independently now.
- **The slingshot left at the wrong angle on a long pull** (the `TODO`). The heading math it
  pointed at is correct; `particle.update` caps how far a particle moves down each frame but
  never how far it moves sideways, so a fast downward shot crawled down while still racing
  across. Aiming 45° down-left: at a 600px pull it left at 168.8° instead of 135°. Aimed
  *up*-left at the same speed the error stayed under half a degree, which is why it only ever
  showed pointing down.
- Each bubble pair is now resolved once per frame instead of as both `(A,B)` and `(B,A)` —
  `resolveParticleCollision` early-returns the second time but `adjustParticlePositions`
  doesn't, so the positional correction was applied twice.
- A pointer released outside the canvas, or cancelled by the browser, is no longer stranded in
  `activePointers` drawing its slingshot preview until the next interstitial.
- The deferred `showLevelInterstitial` timer is cancellable, so losing your last life inside
  its 600ms window can't let it restart the game-over screen behind you.

## Robustness

- A malformed `?level=` payload no longer blanks the game — `JSON.parse(atob(...))` ran
  unguarded at import time. `getGradientBitmap` falls back to the white bubble instead of
  throwing on a colour it hasn't pre-rendered.
- Closed the `rgba()` string in the bubble rim gradient. `addColorStop` runs at module import,
  so an engine strict about the missing paren would fail the game to boot.
- Text and buttons reposition on resize. Centred text captured `getWidth() / 2` once, and the
  continue button built its `Path2D` at the initial width while its transform read the width
  live. On mobile this fires every time the URL bar shows or hides. `devicePixelRatio` is
  re-read too, instead of being captured once.
- The grid's "+N" badge was skipped when the first truncated item was index 0, and the last
  cell was always surrendered to the badge — so a grid that filled exactly hid a real item to
  show "+1".
- Tutorial arrows animate again. The step data is built once and captured `stepStarted` by
  value, so by the blast and slingshot steps the arrow snapped straight to its end position.
- The builder's arrow keys write to `ball.v`, not `ball.velocity`, and `par`/`gravity` are
  parsed out of their inputs — as strings, an exported level's par was concatenated rather
  than summed.

## Three behaviour changes worth a second opinion

1. **Space/Enter now waits for the button's own delay** instead of dismissing instantly. It
   matches the button, but it does mean the end screen can't be skipped immediately.
2. **The continue button keeps one colour.** The two widths each called `randomColor()`, so it
   changed colour the moment a share button appeared beside it. It still never varies between
   interstitials — happy to make it re-roll if that was the intent.
3. **Bubble-vs-bubble collisions still run off-screen, deliberately.** Six 88px bubbles can't
   fit in a 375px row, so on phones they rely on pushing each other apart above the fold.
   Gating that on visibility too would make a packed row arrive overlapped and visibly shove
   itself apart on camera. Only the bubble-vs-projectile pass got the `inViewport()` filter.

## Verification

No test suite, so this was driven in Chromium against a local server.

- `navigator.share` confirmed to run **before `share()` returns** — the actual fix. Payload
  carries an 85KB `image/jpeg` and the right text. No unhandled rejections on cancel.
- Share image rendered and inspected: full card, nothing clipped, every blast and slingshot
  icon drawn with its correct combo count, two captures of the same run identical.
- Slingshot angle error at a 600px pull: **33.8° → 0.1°**, now matching the upward case.
- Wall bouncing compared against `main` for the fast horizontal bubbles in levels 8 and 15
  (`vx` 40/62/70), spawned above the screen and on screen: identical bounce counts and bounds.
  One difference — on `main` a bubble near the bottom edge could **escape sideways past the
  wall** (x reached 31 with a 44px radius), because the old chain skipped `onLeftTouch`
  whenever the vertical case matched first. It now stays in bounds.
- Scoring, empty-category sums, grid truncation and the edge-hugging particle checked directly
  against the modules.
- Smoke tests with zero page errors and zero unhandled rejections: full tutorial, 40
  keypresses through the last level, simultaneous multi-touch blasts, a pointer cancelled
  mid-gesture, a drag released off-canvas, two viewport changes mid-interstitial, and a
  malformed `?level=`.

## Not included

Nine lower-priority findings are written up but untouched — the `rgba(0,0,0,0.6)` overlay
making end-game share images darker than mid-game ones (a design call), `getBitmap()` being
destructive, `particle.update` clamping displacement rather than velocity so `velocity.y` grows
unbounded, orphaned spring promises, and the absence of a `visibilitychange` pause while every
timer runs on `Date.now()`.

Two follow-ups worth their own pass:

- `CAPTURE_DELAYS` in `shareImage.js` is coupled to the button delays in `index.js` and the
  slide-up duration in `scoreDisplay.js` with nothing linking them. Retuning a button delay
  would silently move the capture back into the animation. Passing `msElapsed` through to
  `draw()` would make the coupling explicit.
- Now that a hard downward slingshot covers as much ground per frame as a hard sideways one
  always has, it can outrun the collision check at extreme pulls. The "De-OP the slingshot"
  ideas in `notes.md` would address it properly.