### PR TITLE
Fix the level builder losing edits, crashing, and emitting bad preview links

### DIFF
--- a/builder/index.js
+++ b/builder/index.js
@@ -6,6 +6,7 @@ import {
   makeLevelBall,
   makeLevelEmptyCell,
   makeLevelEmptyRow,
+  encodeLevel,
 } from "../levelData.js";
 
 let currentlyDisplayedData = {
@@ -41,33 +42,36 @@ const populateListOfLevels = () => {
 
 const updateName = (newName) => (currentlyDisplayedData.name = newName);
 
-const updatePar = (newPar) => (currentlyDisplayedData.par = parseInt(newPar));
+const updatePar = (newPar) => {
+  const parsed = parseInt(newPar);
+  if (!Number.isNaN(parsed)) currentlyDisplayedData.par = parsed;
+};
 
-const updateGravity = (newGrav) =>
-  (currentlyDisplayedData.gravity = parseFloat(newGrav));
+const updateGravity = (newGrav) => {
+  const parsed = parseFloat(newGrav);
+  if (!Number.isNaN(parsed)) currentlyDisplayedData.gravity = parsed;
+};
 
 const updateLevelHref = () => {
-  openPreviewEl.setAttribute(
-    "href",
-    window.location.href.replace(
-      "/builder/",
-      `/?level=${btoa(JSON.stringify(currentlyDisplayedData))}`
-    )
-  );
+  const encodedLevel = encodeLevel(currentlyDisplayedData);
+  const previewURL = new URL("../", window.location.href);
+  previewURL.search = new URLSearchParams({ level: encodedLevel }).toString();
+
+  openPreviewEl.setAttribute("href", previewURL.toString());
 
   const levelInCodeBlock = `\`\`\` JSON\n${JSON.stringify(
     currentlyDisplayedData
   )}\n\`\`\``;
-  const playLink = `[Play Preview](https://ehmorris.com/bubbles/?level=${btoa(
-    JSON.stringify(currentlyDisplayedData)
+  const playLink = `[Play Preview](https://ehmorris.com/bubbles/?level=${encodeURIComponent(
+    encodedLevel
   )})`;
   const discussionText = `Please write something interesting here about this level\n---\n${levelInCodeBlock}\n\n${playLink}`;
 
   submitLevelEl.setAttribute(
     "href",
-    `https://github.com/ehmorris/bubbles/discussions/new?category=level-suggestions&title=${
+    `https://github.com/ehmorris/bubbles/discussions/new?category=level-suggestions&title=${encodeURIComponent(
       currentlyDisplayedData.name
-    }&body=${encodeURIComponent(discussionText)}`
+    )}&body=${encodeURIComponent(discussionText)}`
   );
 };
 
@@ -104,7 +108,7 @@ const clearSelection = () => {
 };
 
 const deleteRow = (rowIndex) => {
-  if (rowIndex === selectedBallRow) clearSelection();
+  clearSelection();
 
   currentlyDisplayedData.balls.splice(rowIndex, 1);
 };
@@ -118,8 +122,13 @@ const addRow = () => {
     selectCell(parseInt(selectedBallRow) + 1, selectedBallCell);
 };
 
-const copyJSON = () =>
-  navigator.clipboard.writeText(`${JSON.stringify(currentlyDisplayedData)},`);
+const copyJSON = () => {
+  if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+
+  navigator.clipboard
+    .writeText(`${JSON.stringify(currentlyDisplayedData)},`)
+    .catch(() => {});
+};
 
 layoutNameEl.addEventListener("input", (e) => {
   updateName(e.target.value);
@@ -144,24 +153,30 @@ addRowEl.addEventListener("pointerdown", addRow);
 copyToClipboardEl.addEventListener("pointerdown", copyJSON);
 
 document.addEventListener("keydown", (e) => {
-  const { shiftKey, ctrlKey, key, repeat } = e;
+  const { shiftKey, ctrlKey, metaKey, key, repeat } = e;
+  const bareKey = !repeat && !shiftKey && !ctrlKey && !metaKey;
 
   if (document.activeElement.tagName === "INPUT") return false;
 
   // Action keyboard shortcuts
-  if (!repeat && !shiftKey && !ctrlKey && key === "r") {
+  if (bareKey && key === "r") {
     addRow();
     addRowEl.classList.add("actionsTop-button--active");
-  } else if (!repeat && key === "c") {
+  } else if (bareKey && key === "c") {
     copyJSON();
     copyToClipboardEl.classList.add("actionsBottom-button--active");
   }
 
   // Selected ball actions
   else if (selectedBallRow && selectedBallCell) {
-    const ball =
-      currentlyDisplayedData.balls[selectedBallRow][selectedBallCell];
+    const selectedRow = currentlyDisplayedData.balls[selectedBallRow];
+    const ball = selectedRow && selectedRow[selectedBallCell];
     const cellIndexInt = parseInt(selectedBallCell);
+
+    if (!ball) {
+      clearSelection();
+      return;
+    }
 
     // Adjust values
     if (key === "Backspace") {
@@ -252,8 +267,9 @@ document.addEventListener("pointerdown", ({ target }) => {
     deleteRow(clickedEl.getAttribute("data-row-index"));
     drawLevel();
   } else if (elIsLevel) {
-    currentlyDisplayedData =
-      gameLevels[clickedEl.getAttribute("data-level-index")];
+    currentlyDisplayedData = structuredClone(
+      gameLevels[clickedEl.getAttribute("data-level-index")]
+    );
     clearSelection();
     drawLevel();
     populateListOfLevels();

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ import { makeInterstitialButtonManager } from "./interstitialButton.js";
 import { makeActivePointer } from "./activePointer.js";
 import { makeTextBlock } from "./textBlock.js";
 import { makeScoreDisplay } from "./scoreDisplay.js";
-import { makeLevelBalls } from "./levelData.js";
+import { makeLevelBalls, decodeLevel } from "./levelData.js";
 import { makeScoreStore } from "./scoreStore.js";
 import { makeTutorialManager } from "./tutorial.js";
 import { makeFirework } from "./firework.js";
@@ -32,7 +32,7 @@ function parsePreviewData(encodedLevel) {
   if (!encodedLevel) return false;
 
   try {
-    const parsed = JSON.parse(atob(encodedLevel));
+    const parsed = decodeLevel(encodedLevel);
     return Array.isArray(parsed?.balls) ? parsed : false;
   } catch (e) {
     return false;

--- a/levelData.js
+++ b/levelData.js
@@ -731,6 +731,21 @@ export const countLevelBalls = ({ balls }) =>
 
 export const getLevelDataByNumber = (level) => levels[level - 1];
 
+export const encodeLevel = (level) => {
+  const bytes = new TextEncoder().encode(JSON.stringify(level));
+  let binary = "";
+  bytes.forEach((byte) => (binary += String.fromCharCode(byte)));
+
+  return btoa(binary);
+};
+
+export const decodeLevel = (encoded) =>
+  JSON.parse(
+    new TextDecoder().decode(
+      Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0))
+    )
+  );
+
 export const makeLevelBalls = (canvasManager, level, onPop, onMiss) => {
   const balls = [];
   level.balls.forEach((row, rowIndex) => {


### PR DESCRIPTION
## Why

The earlier pass only glanced at `builder/` — it caught the arrow keys writing to `ball.velocity` and `par`/`gravity` exporting as strings, but the builder was never actually run. Driving it in a browser turned up seven more bugs, four of which break the thing the builder exists for: producing a working preview link.

## Preview and submit links

**Opening the builder as `/builder/index.html` produced a broken link.** The URL was built with `href.replace("/builder/", ...)`, which on `.../builder/index.html` yields `.../?level=<payload>index.html`. The trailing text corrupts the payload, so the link silently plays the normal game. It only worked when the builder was opened as a directory. Built from a resolved `URL` now.

**The base64 payload went into the query string raw.** The game reads it back with `URLSearchParams.get()`, which turns `+` into a space; `atob` then strips the space and throws, so the link silently plays the normal game instead of the level. None of the 16 shipped levels hit this, but ~4% of names drawn from a character set including punctuation do — anything with `>` is an easy reproducer. The payload is percent-encoded now.

**`btoa` threw outright on any name outside Latin-1.** Typing an accent or an emoji left *both* links frozen at their previous value and logged an error on every keystroke — no feedback that the link had stopped updating. Payloads are UTF-8 encoded before base64 via shared `encodeLevel`/`decodeLevel` helpers in `levelData.js`, so the game decodes symmetrically. Existing ASCII links decode unchanged (verified).

**The GitHub submit link interpolated the level name unencoded**, so a name containing `&` or `#` truncated the discussion title.

## Editing

**Loading a built-in level assigned it by reference**, so every edit mutated the imported `levels` array. Switching away and back showed your edits still applied, with no way to recover the original short of a reload. Cloned now.

**Deleting a row could crash the next keypress.** The selection was only cleared when the deleted row *was* the selected row, but any delete shifts the rows below it. Select a ball on the last row, delete the first row, press an arrow key → `Cannot read properties of undefined (reading '0')`. The selection is cleared on any delete, and the keyboard handler bails if the selection no longer points at a ball.

**Cmd+C and Ctrl+C overwrote the clipboard with level JSON** instead of copying your selection — the `c` shortcut checked no modifiers while `r` checked two. Both check all of them now.

## Smaller

- Clearing the par field set `par` to `NaN`, which serialised to `null` and gave the preview `Par of null`. It keeps the last valid value instead.
- `copyJSON` no longer assumes `navigator.clipboard` exists or that the write resolves.

## Verification

No test suite, so this was driven in Chromium against a local server. Each bug was reproduced first, then confirmed fixed.

- **End-to-end round trip** — build a level in the builder, follow its own Preview link into the game, confirm the game enters preview mode with the right name. Passes for `Waterfall`, `Café 🫧 étage`, `Chaos > Order & co`, and when entering the builder via `/builder/index.html`. Zero errors on either side.
- **Backward compatibility** — a legacy raw-base64 ASCII link still loads (`Bubbles! - "OLD LINK"`).
- **Regressions reproduced before/after**: stale-selection crash (page error → none), non-ASCII name (`btoa` error, link frozen → link updates), cleared par (`null` → last valid value), built-in level mutation (edits leaked → original restored), Ctrl+C (clipboard hijacked → preserved).
- **Game suite unaffected** by the `index.js`/`levelData.js` changes: share still synchronous with a correct 85KB JPEG payload, slingshot angle error still 0.1°, and the tutorial / keyboard-mash / multi-touch / malformed-`?level=` smoke tests all clean.

## Noted, not changed

- `makeNameHTML` and `makeGravityHTML` in `builder/makeHTML.js` are exported but never called — `index.html` hardcodes those inputs. Dead code that looks live.
- The level list labels entries with the 0-based array index, so `LEVEL 1` shows a `0` beside it. Might be deliberate for copy-pasting into `levelData.js`, so I left it.
- The par input is `type="number"` with `maxlength="3"`, which does nothing on number inputs, and has no `min`, so negative par is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC457EsB9G7y1QXo2uDysx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HC457EsB9G7y1QXo2uDysx)_